### PR TITLE
Fix "return_statements" issue in src/Controllers/Reports/GenerateReportController.php

### DIFF
--- a/src/Controllers/Reports/GenerateReportController.php
+++ b/src/Controllers/Reports/GenerateReportController.php
@@ -49,7 +49,7 @@ class GenerateReportController extends Controller
             'targets' => (new TargetRepository($this->db))->findByProjectId($id),
             'tasks' => (new TaskRepository($this->db))->findByProjectId($id),
             'vulnerabilities' => $vulnerabilities,
-            'findingsOverview' => $this->createFindingsOverview($vulnerabilities)
+            'findingsOverview' => $this->createFindingsOverview($vulnerabilities),
         ]);
     }
 
@@ -84,11 +84,15 @@ class GenerateReportController extends Controller
     public function createResponse(int $reportId, string $format, string $html): Response
     {
         $filename = sprintf("report-%d.%s", $reportId, $format);
+        $response = "";
 
         if ($format === 'html') {
-            return $this->createHtmlFormatResponse($filename, $html);
+            $response = $this->createHtmlFormatResponse($filename, $html);
+        } else {
+            $response = $this->createPdfFormatResponse($html, $filename);
         }
-        return $this->createPdfFormatResponse($html, $filename);
+
+        return $response;
     }
 
 


### PR DESCRIPTION
From what I can tell most of the multiple return statements have to do with the various `array_map` functions being used, returning their values to the assigned variable. I did refactor the createResponse method to have only a single return statement.   To do so I assign the formatted response to a variable `$response` and then return that variable.

